### PR TITLE
feat: add support for ssh-key authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,14 +176,17 @@ caster@kali:~$ sara -h
 Sara supports the following command line options:
 
 ```bash
-usage: sara.py [-h] --ip IP --username USERNAME --password PASSWORD [--port PORT]
+usage: sara.py [-h] [--ip IP] [--username USERNAME] [--password PASSWORD] [--ssh-key SSH_KEY] [--passphrase PASSPHRASE] [--port PORT]
 
 options:
-  -h, --help           show this help message and exit
-  --ip IP              The address of your MikroTik router
-  --username USERNAME  SSH username (RO account can be used)
-  --password PASSWORD  SSH password
-  --port PORT          SSH port (default: 22)
+  -h, --help            show this help message and exit
+  --ip IP               The address of your MikroTik router
+  --username USERNAME   SSH username (RO account can be used)
+  --password PASSWORD   SSH password
+  --ssh-key SSH_KEY     SSH key
+  --passphrase PASSPHRASE
+                        SSH key passphrase
+  --port PORT           SSH port (default: 22)
 ```
 
 1. `--ip` - this argument specifies the IP address of the MikroTik device to which Sara is connecting;
@@ -194,7 +197,15 @@ options:
 
 3. `--password` - password for SSH authentication;
 
-4. `--port` - allows you to specify a non-standard SSH port for connection. The default is **22**, but if you have changed the SSH port number, it must be specified manually.
+4. `--ssh-key` - specifies the ssh key that should be used to access the RouterOS's shell
+
+    > This is muaually exclusive with `--password`.
+
+5. `--passphrase` - specifies the passphrase used to access the ssh-key
+
+    > This only works when using the `--ssh-key` argument.
+
+6. `--port` - allows you to specify a non-standard SSH port for connection. The default is **22**, but if you have changed the SSH port number, it must be specified manually.
 
 # Sara's Launch
 

--- a/sara.py
+++ b/sara.py
@@ -44,13 +44,14 @@ def banner():
     print()
 
 # Establish SSH connection to the RouterOS device using Netmiko
-def connect_to_router(ip, username, password, port):
+def connect_to_router(ip, username, password, port, key_file):
     device = {
         "device_type": "mikrotik_routeros",
         "host": ip,
         "username": username,
         "password": password,
         "port": port,
+        "key_file": key_file,
     }
     try:
         print(Fore.GREEN + Style.BRIGHT + f"[*] Connecting to RouterOS at {ip}:{port}")
@@ -741,6 +742,7 @@ def main():
     parser.add_argument("--ip", help="The address of your MikroTik router")
     parser.add_argument("--username", help="SSH username (RO account can be used)")
     parser.add_argument("--password", help="SSH password")
+    parser.add_argument("--ssh-key", help="SSH key")
     parser.add_argument("--port", type=int, default=22, help="SSH port (default: 22)")
     args = parser.parse_args()
 
@@ -748,10 +750,21 @@ def main():
         parser.print_help()
         sys.exit(0)
 
-    if not args.ip or not args.username or not args.password:
+    if not args.ip:
         print(Fore.YELLOW + Style.BRIGHT + "[!] ERROR: Missing required arguments")
         print(Fore.YELLOW + "[!] Use 'sara --help' for more information")
         sys.exit(1)
+
+    if not args.username or (not args.password and not args.ssh_key):
+        print(Fore.YELLOW + Style.BRIGHT + "[!] ERROR: Missing required arguments")
+        print(Fore.YELLOW + "[!] Use 'sara --help' for more information")
+        sys.exit(1)
+
+    if args.password and args.ssh_key:
+        print(Fore.YELLOW + Style.BRIGHT + "[!] ERROR: Can't use both password & ssh_key authentication")
+        print(Fore.YELLOW + "[!] Use 'sara --help' for more information")
+        sys.exit(1)
+        
 
     confirm_legal_usage()
 
@@ -759,7 +772,7 @@ def main():
     start_time = time.time()
 
     # Connecting to the router
-    connection = connect_to_router(args.ip, args.username, args.password, args.port)
+    connection = connect_to_router(args.ip, args.username, args.password, args.port, args.ssh_key)
 
     # Execute all implemented security checks in sequence
     check_routeros_version(connection)

--- a/sara.py
+++ b/sara.py
@@ -44,7 +44,7 @@ def banner():
     print()
 
 # Establish SSH connection to the RouterOS device using Netmiko
-def connect_to_router(ip, username, password, port, key_file):
+def connect_to_router(ip, username, password, port, key_file, passphrase):
     device = {
         "device_type": "mikrotik_routeros",
         "host": ip,
@@ -52,6 +52,7 @@ def connect_to_router(ip, username, password, port, key_file):
         "password": password,
         "port": port,
         "key_file": key_file,
+        "passphrase": passphrase,
     }
     try:
         print(Fore.GREEN + Style.BRIGHT + f"[*] Connecting to RouterOS at {ip}:{port}")
@@ -743,6 +744,7 @@ def main():
     parser.add_argument("--username", help="SSH username (RO account can be used)")
     parser.add_argument("--password", help="SSH password")
     parser.add_argument("--ssh-key", help="SSH key")
+    parser.add_argument("--passphrase", help="SSH key passphrase")
     parser.add_argument("--port", type=int, default=22, help="SSH port (default: 22)")
     args = parser.parse_args()
 
@@ -764,7 +766,12 @@ def main():
         print(Fore.YELLOW + Style.BRIGHT + "[!] ERROR: Can't use both password & ssh_key authentication")
         print(Fore.YELLOW + "[!] Use 'sara --help' for more information")
         sys.exit(1)
-        
+    
+    if args.passphrase and not args.ssh_key:
+        print(Fore.YELLOW + Style.BRIGHT + "[!] ERROR: The passphrase argument can't be used when not specifying a ssh_key")
+        print(Fore.YELLOW + "[!] Use 'sara --help' for more information")
+        sys.exit(1)
+    
 
     confirm_legal_usage()
 
@@ -772,7 +779,13 @@ def main():
     start_time = time.time()
 
     # Connecting to the router
-    connection = connect_to_router(args.ip, args.username, args.password, args.port, args.ssh_key)
+    connection = connect_to_router(args.ip,
+        args.username,
+        args.password,
+        args.port,
+        args.ssh_key,
+        args.passphrase
+    )
 
     # Execute all implemented security checks in sequence
     check_routeros_version(connection)


### PR DESCRIPTION
Hi! Thank you for your work on this tool

This PR is a simple patch enabling the use of ssh keys to authenticate to the RouterOS's ssh server

It basically adds arguments to Sara in order to populate the netmiko parameters (`key_file` and `passphrase`)